### PR TITLE
Handle Roku info more robustly

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -96,39 +96,13 @@ module.exports = function(deviceIp, MockReq) {
 
           xml(res.text, reject, json => {
             json = json['device-info']
+            flatJson = {};
 
-            const info = Im.Map({
-              'udn': json['udn'][0],
-              'serial-number': json['serial-number'][0],
-              'device-id': json['device-id'][0],
-              'advertising-id': json['advertising-id'][0],
-              'vendor-name': json['vendor-name'][0],
-              'model-name': json['model-name'][0],
-              'model-number': json['model-number'][0],
-              'model-region': json['model-region'][0],
-              'wifi-mac': json['wifi-mac'][0],
-              'ethernet-mac': json['ethernet-mac'][0],
-              'network-type': json['network-type'][0],
-              'user-device-name': json['user-device-name'][0],
-              'software-version': json['software-version'][0],
-              'software-build': json['software-build'][0],
-              'secure-device': json['secure-device'][0],
-              'language': json['language'][0],
-              'country': json['country'][0],
-              'locale': json['locale'][0],
-              'time-zone': json['time-zone'][0],
-              'time-zone-offset': json['time-zone-offset'][0],
-              'power-mode': json['power-mode'][0],
-              'supports-suspend': json['supports-suspend'][0],
-              'developer-enabled': json['developer-enabled'][0],
-              'keyed-developer-id': json['keyed-developer-id'][0],
-              'search-enabled': json['search-enabled'][0],
-              'voice-search-enabled': json['voice-search-enabled'][0],
-              'notifications-enabled': json['notifications-enabled'][0],
-              'notifications-first-use': json['notifications-first-use'][0],
-              'headphones-connected': json['headphones-connected'][0]
-            })
+            Object.entries(json).forEach(([key, value]) => {
+              flatJson[key] = value[0];
+            });
 
+            const info = Im.Map(flatJson);
             return resolve(info)
           })
         })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodeku",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Don't assume all info values will be present across all Roku devices.
Instead, flatten the parsed xml into json and expect the user to inspect
for the values they need.

I was running this with my Roku TV and some of these values weren't in the map, causing some exceptions when trying to get the first element of the array.