### PR TITLE
Accommodate malformed SSDP responses missing a SERVER header

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -33,7 +33,7 @@ module.exports = function (timeout) {
       // Roku devices operate on PORT 8060
       const ipAddress = /(\d+.*:8060)(?=\/)/.exec(headers.LOCATION);
 
-      if (Boolean(~headers.SERVER.search(/Roku/)) && ipAddress) {
+      if ('SERVER' in headers && Boolean(~headers.SERVER.search(/Roku/)) && ipAddress) {
         clearInterval(intervalId);
         clearTimeout(timeoutId);
 


### PR DESCRIPTION
Skip any responses that do not include a SERVER header as they are malformed and will not process correctly.