### PR TITLE
Limit SSDP search to only roku devices

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -14,7 +14,7 @@ module.exports = function (timeout) {
 
     // Open the flood gates
     const intervalId = setInterval(() => {
-      client.search('ssdp:all');
+      client.search('roku:ecp');
     }, 1000);
 
     // Discovery timeout for roku device; default 10000ms


### PR DESCRIPTION
Per Roku API documentation limit SSDP search to 'roku:ecp' for the ST header. 

Roku documentation at https://sdkdocs.roku.com/display/sdkdoc/External+Control+API#ExternalControlAPI-SSDP(SimpleServiceDiscoveryProtocol)