### PR TITLE
Handle case where there is no active app and .active() is called

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -44,14 +44,25 @@ module.exports = function (deviceIp) {
     .then(json => {
       // Tidy up json data
       return json['active-app'].app.map(app => {
+        // If no app is currently active, a single field is returned without
+        // any properties
+        if (!app.$ || !app.$.id) {
+          return null;
+        }
         return {
           id: app.$.id,
           name: app._,
           type: app.$.type,
           version: app.$.version
         };
-      });
+      }).filter(app => app !== null);
     });
+
+  const activeApp = () => {
+    return active().then(active => {
+      return active.length === 0 ? null : active[0];
+    });
+  };
 
   const info = () => req(endpoints.get('info'))
     .then(res => res.body.toString())
@@ -80,6 +91,7 @@ module.exports = function (deviceIp) {
     ip,
     apps,
     active,
+    activeApp,
     info,
     icon,
     launch,

--- a/test/nodeku.test.js
+++ b/test/nodeku.test.js
@@ -72,6 +72,18 @@ wrapper('-method: .active()', (t, device) => {
     });
 });
 
+wrapper('-method: .activeApp()', (t, device) => {
+  return device
+    .activeApp()
+    .then(app => {
+      t.true(Array.isArray(app), 'returns list');
+
+      const objectHasCorrectProps = !assert.deepEqual(
+        Object.keys(app), ['id', 'name', 'type', 'version']);
+      t.true(objectHasCorrectProps, 'map has correct props');
+    });
+});
+
 wrapper('-method: .info()', (t, device) => {
   return device
     .info()


### PR DESCRIPTION
When there are no active apps, roku returns a sigle <app> field without
any properties. Trying to access app.$.id resutls in an error. Instead,
return an empty array in that case. Also added activeApp method, which
unwraps the array since it will only ever have one element.